### PR TITLE
Cleanup Initializer

### DIFF
--- a/packages/ember-simple-auth/lib/simple-auth/configuration.js
+++ b/packages/ember-simple-auth/lib/simple-auth/configuration.js
@@ -155,7 +155,7 @@ export default {
     @method load
     @private
   */
-  load: loadConfig(defaults, function(container, config) {
+  load: loadConfig(defaults, function(container) {
     this.applicationRootUrl = container.lookup('router:main').get('rootURL') || '/';
   })
 };

--- a/packages/ember-simple-auth/lib/simple-auth/initializer.js
+++ b/packages/ember-simple-auth/lib/simple-auth/initializer.js
@@ -1,12 +1,10 @@
 import Configuration from './configuration';
-import getGlobalConfig from './utils/get-global-config';
 import setup from './setup';
 
 export default {
   name:       'simple-auth',
   initialize: function(container, application) {
-    var config = getGlobalConfig('simple-auth');
-    Configuration.load(container, config);
+    Configuration.load(container);
     setup(container, application);
   }
 };


### PR DESCRIPTION
When calling `simple-auth/configuration`'s `#load` function, the
`config` parameter is ignored.

Once it is removed from the parameters list, the call site (within the
initializer) no longer requires the `'./utils/get-global-config'` module
to be imported.
